### PR TITLE
Implemented the Python attribute protocol

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -67,6 +67,32 @@ class FromStringTestCase(unittest.TestCase):
     def test_single_root(self):
         self.assert_(untangle.parse('<single_root_node/>'))
 
+    def test_attribute_protocol(self):
+        o = untangle.parse('''
+                    <root>
+                     <child name="child1">
+                        <subchild name="sub1"/>
+                     </child>
+                     <child name="child2"/>
+                     <child name="child3">
+                        <subchild name="sub2"/>
+                        <subchild name="sub3"/>
+                     </child>
+                    </root>
+                     ''')
+        try:
+            self.assertEquals(None, o.root.child.inexistent)
+            self.fail('Was able to access inexistent child as None')
+        except AttributeError:
+            pass  # this is the expected error
+        except IndexError:
+            self.fail('Caught IndexError quen expecting AttributeError')
+
+        self.assertTrue(hasattr(o.root, 'child'))
+        self.assertFalse(hasattr(o.root, 'inexistent'))
+
+        self.assertEqual('child1', getattr(o.root, 'child')[0]['name'])
+
 
 class InvalidTestCase(unittest.TestCase):
     """ Test corner cases """
@@ -255,6 +281,7 @@ class UntangleInObjectsTestCase(unittest.TestCase):
         self.assertEquals('1', foo.doc.a.b['x'])
         self.assertEquals('foo', foo.doc.a.b.cdata)
 
+
 class UrlStringTestCase(unittest.TestCase):
     """ tests is_url() function """
     def test_is_url(self):
@@ -263,6 +290,7 @@ class UrlStringTestCase(unittest.TestCase):
         self.assertFalse(untangle.is_url(7))
         self.assertTrue(untangle.is_url('http://foobar'))
         self.assertTrue(untangle.is_url('https://foobar'))
+
 
 class TestSaxHandler(unittest.TestCase):
     """ Tests the SAX ContentHandler """

--- a/untangle.py
+++ b/untangle.py
@@ -80,7 +80,14 @@ class Element(object):
                 self.__dict__[key] = matching_children
                 return matching_children
         else:
-            raise IndexError('Unknown key <%s>' % key)
+            raise AttributeError(
+                "'%s' has no attribute '%s'" % (self._name, key)
+            )
+
+    def __hasattribute__(self, name):
+        if name in self.__dict__:
+            return True
+        return any(self.children, lambda x: x._name == name)
 
     def __iter__(self):
         yield self


### PR DESCRIPTION
The behavior regarding attributes was unexpected.

Now these work:

    hasattribute(element, 'aname')
    getattribute(element, 'aname', [])