### PR TITLE
Add parse_raw() to handle large XML strings

### DIFF
--- a/untangle.py
+++ b/untangle.py
@@ -146,7 +146,6 @@ class Handler(handler.ContentHandler):
     def characters(self, cdata):
         self.elements[-1].add_cdata(cdata)
 
-
 def parse(filename):
     """
     Interprets the given string as a filename, URL or XML data string,
@@ -173,6 +172,27 @@ def parse(filename):
 
     return sax_handler.root
 
+
+def parse_raw(xml):
+    """
+    Parses the given string as an XML data string, returning a Python
+    object which represents the document.
+
+    Raises ``ValueError`` if the argument is None / empty string.
+
+    Raises ``xml.sax.SAXParseException`` if something goes wrong
+    during parsing.
+    """
+    if (xml is None or not is_string(xml) or xml.strip() == ''):
+        raise ValueError('parse_raw() takes an XML string')
+
+    parser = make_parser()
+    sax_handler = Handler()
+    parser.setContentHandler(sax_handler)
+
+    parser.parse(StringIO(xml))
+
+    return sax_handler.root
 
 def is_url(string):
     """


### PR DESCRIPTION
In Windows environments the path length limitation causes a path too long exception to be raised from `parse()`. To combat this, I've written a `parse_raw()` function that accepts an XML string and will not attempt to estimate what type of data it was given. This seemed like a better choice over adding a type parameter to `parse()` because of the several options it could be given: filepath, url, xml string, stream, or some value to indicate that it needs to be figured out (like `None`). 

This has been confirmed to work on Windows 7 with Python 3.4.3 using a document that exceeds 300+ characters.
