### PR TITLE
Optional xml.sax features

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -332,6 +332,28 @@ class FigsTestCase(unittest.TestCase):
         assert expected_pairs == pairs
 
 
+class ParserFeatureTestCase(unittest.TestCase):
+    """Tests adding xml.sax parser features via parse()"""
+
+    xml_str = """<?xml version="1.0" standalone="no" ?>
+        <!DOCTYPE FOO PUBLIC "foo" "http://256.0.0.1/foo.dtd">
+        <foo bar="baz" />"""
+
+    def test_valid_feature(self):
+        # xml.sax.handler.feature_external_ges -> load external general (text)
+        # entities, such as DTDs
+        doc = untangle.parse(self.xml_str, feature_external_ges=False)
+        self.assertEqual(doc.foo['bar'], 'baz')
+
+    def test_invalid_feature(self):
+        with self.assertRaises(AttributeError):
+            untangle.parse(self.xml_str, invalid_feature=True)
+
+    def test_invalid_external_dtd(self):
+        with self.assertRaises(IOError):
+            untangle.parse(self.xml_str, feature_external_ges=True)
+
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -335,23 +335,24 @@ class FigsTestCase(unittest.TestCase):
 class ParserFeatureTestCase(unittest.TestCase):
     """Tests adding xml.sax parser features via parse()"""
 
-    xml_str = """<?xml version="1.0" standalone="no" ?>
+    # External DTD that will never be loadable (invalid address)
+    bad_dtd_xml = """<?xml version="1.0" standalone="no" ?>
         <!DOCTYPE FOO PUBLIC "foo" "http://256.0.0.1/foo.dtd">
         <foo bar="baz" />"""
 
     def test_valid_feature(self):
         # xml.sax.handler.feature_external_ges -> load external general (text)
         # entities, such as DTDs
-        doc = untangle.parse(self.xml_str, feature_external_ges=False)
+        doc = untangle.parse(self.bad_dtd_xml, feature_external_ges=False)
         self.assertEqual(doc.foo['bar'], 'baz')
 
     def test_invalid_feature(self):
         with self.assertRaises(AttributeError):
-            untangle.parse(self.xml_str, invalid_feature=True)
+            untangle.parse(self.bad_dtd_xml, invalid_feature=True)
 
     def test_invalid_external_dtd(self):
         with self.assertRaises(IOError):
-            untangle.parse(self.xml_str, feature_external_ges=True)
+            untangle.parse(self.bad_dtd_xml, feature_external_ges=True)
 
 
 if __name__ == '__main__':

--- a/untangle.py
+++ b/untangle.py
@@ -147,13 +147,21 @@ class Handler(handler.ContentHandler):
         self.elements[-1].add_cdata(cdata)
 
 
-def parse(filename):
+def parse(filename, **parser_features):
     """
     Interprets the given string as a filename, URL or XML data string,
     parses it and returns a Python object which represents the given
     document.
 
-    Raises ``ValueError`` if the argument is None / empty string.
+    Extra arguments to this function are treated as feature values to pass
+    to ``parser.setFeature()``. For example, ``feature_external_ges=False``
+    will set ``xml.sax.handler.feature_external_ges`` to False, disabling
+    the parser's inclusion of external general (text) entities such as DTDs.
+
+    Raises ``ValueError`` if the first argument is None / empty string.
+
+    Raises ``AttributeError`` if a requested xml.sax feature is not found in
+    ``xml.sax.handler``.
 
     Raises ``xml.sax.SAXParseException`` if something goes wrong
     during parsing.
@@ -161,6 +169,8 @@ def parse(filename):
     if (filename is None or (is_string(filename) and filename.strip()) == ''):
         raise ValueError('parse() takes a filename, URL or XML string')
     parser = make_parser()
+    for feature, value in parser_features.items():
+        parser.setFeature(getattr(handler, feature), value)
     sax_handler = Handler()
     parser.setContentHandler(sax_handler)
     if is_string(filename) and (os.path.exists(filename) or is_url(filename)):


### PR DESCRIPTION
I'm using `untangle` to parse XML files and it's great.  However, I'm operating offline, and by default `xml.sax` tries to load external entities such as DTDs.  Loading external entities is a controllable parser "feature."

This PR adds the ability to pass `xml.sax` parser features as extra arguments to `parse()`, so for example

``` python
untangle.parse(my_xml, feature_external_ges=False)
```

becomes

``` python
parser.setFeature(xml.sax.handler.feature_external_ges, False)
```

`parse()` raises `AttributeError` if a nonexistent feature is requested.
