### PR TITLE
support 'in' and 'not in' operator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Christian Stefanescu <chris@0chris.com>
 
 Florian Idelberger <flo@terrorpop.de>
 Apalala <apalala@gmail.com>
+Reverb Chu <reverbc@me.com>

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -14,6 +14,10 @@ class FromStringTestCase(unittest.TestCase):
         self.assert_(o.a is not None)
         self.assert_(o.a.b is not None)
         self.assert_(o.a.c is not None)
+        self.assert_('a' in o)
+        self.assert_('b' in o.a)
+        self.assert_('c' in o.a)
+        self.assert_('d' not in o.a)
 
     def test_basic_with_decl(self):
         o = untangle.parse("<?xml version='1.0'?><a><b/><c/></a>")
@@ -21,6 +25,10 @@ class FromStringTestCase(unittest.TestCase):
         self.assert_(o.a is not None)
         self.assert_(o.a.b is not None)
         self.assert_(o.a.c is not None)
+        self.assert_('a' in o)
+        self.assert_('b' in o.a)
+        self.assert_('c' in o.a)
+        self.assert_('d' not in o.a)
 
     def test_with_attributes(self):
         o = untangle.parse('''

--- a/untangle.py
+++ b/untangle.py
@@ -119,6 +119,9 @@ class Element(object):
     def __len__(self):
         return len(self.children)
 
+    def __contains__(self, key):
+        return key in dir(self)
+
 
 class Handler(handler.ContentHandler):
     """


### PR DESCRIPTION
Adding support for the `in` and `not in` operator by implementing `__contains__()` method as the following example:

```python
>>> 'child' in untangle.parse('<root/>').root
... False
>>> 'child' in untangle.parse('<root><child>value</child></root>').root
... True
```

This could be useful when dealing with dynamic xml API response.