### PR TITLE
Fix unittest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ),
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest', 'six'],
 )
 
 # vim: set expandtab ts=4 sw=4:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import xml
+import six
 import unittest
 import untangle
-import xml
 
 
 class FromStringTestCase(unittest.TestCase):
@@ -102,12 +103,25 @@ class FromStringTestCase(unittest.TestCase):
         self.assertEqual('child1', getattr(o.root, 'child')[0]['name'])
 
     def test_python_keyword(self):
-        o = untangle.parse("<class><return/><pass/><None/></class>")
+        o = untangle.parse('''
+            <class>
+                <return/>
+                <pass/>
+                <None/>
+                <print/>
+                <exec/>
+                <True/>
+            </class>''')
         self.assert_(o is not None)
         self.assert_(o.class_ is not None)
         self.assert_(o.class_.return_ is not None)
         self.assert_(o.class_.pass_ is not None)
-        self.assert_(o.class_.None_ is not None)
+        if six.PY2:
+            self.assert_(o.class_.print_ is not None)
+            self.assert_(o.class_.exec_ is not None)
+        if six.PY3:
+            self.assert_(o.class_.None_ is not None)
+            self.assert_(o.class_.True_ is not None)
 
 
 class InvalidTestCase(unittest.TestCase):
@@ -367,12 +381,14 @@ class ParserFeatureTestCase(unittest.TestCase):
         self.assertEqual(doc.foo['bar'], 'baz')
 
     def test_invalid_feature(self):
-        with self.assertRaises(AttributeError):
-            untangle.parse(self.bad_dtd_xml, invalid_feature=True)
+        self.assertRaises(
+            AttributeError, untangle.parse,
+            self.bad_dtd_xml, invalid_feature=True)
 
     def test_invalid_external_dtd(self):
-        with self.assertRaises(IOError):
-            untangle.parse(self.bad_dtd_xml, feature_external_ges=True)
+        self.assertRaises(
+            IOError, untangle.parse,
+            self.bad_dtd_xml, feature_external_ges=True)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,10 @@ envlist = flake8, py26, py27, py33, py34, py35, py36, pypy
 skip_missing_interpreters = true
 
 [testenv]
-commands = py.test tests/tests.py
-deps = pytest
+commands = py.test tests/test_untangle.py
+deps =
+    pytest
+    six
 
 [testenv:flake8]
 basepython=python

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = flake8, py26, py27, py33, py34, py35, py36, pypy
 skip_missing_interpreters = true
 
 [testenv]
-commands = py.test tests/test_untangle.py
+commands = py.test tests/tests.py
 deps =
     pytest
     six


### PR DESCRIPTION
For `test_python_keyword` case: some of the keywords are Python 3 only (e.g. `None`) and will cause failure in Py26 and Py27. In this case I've added a few more test cases and use `six` to distinguish them.

For `test_invalid_feature` and `test_invalid_external_dtd` cases: using `assertRaises` as context manager is a feature in Py27 so not compatible with Py26. Switching back to old-school syntax here for backward compatibility.