### PR TITLE
Detect valid pathnames before checking whether a path exists (fixes #45)

### DIFF
--- a/untangle.py
+++ b/untangle.py
@@ -14,7 +14,9 @@
  License: MIT License - http://www.opensource.org/licenses/mit-license.php
 """
 import os
+import sys
 import keyword
+import errno
 from xml.sax import make_parser, handler
 try:
     from StringIO import StringIO
@@ -185,7 +187,7 @@ def parse(filename, **parser_features):
         parser.setFeature(getattr(handler, feature), value)
     sax_handler = Handler()
     parser.setContentHandler(sax_handler)
-    if is_string(filename) and (os.path.exists(filename) or is_url(filename)):
+    if (is_pathname_valid(filename) and os.path.exists(filename)) or (is_string(filename) and is_url(filename)):
         parser.parse(filename)
     else:
         if hasattr(filename, 'read'):
@@ -194,6 +196,92 @@ def parse(filename, **parser_features):
             parser.parse(StringIO(filename))
 
     return sax_handler.root
+
+# Originally based on https://stackoverflow.com/questions/9532499/check-whether-a-path-is-valid-in-python-without-creating-a-file-at-the-paths-ta/34102855#34102855
+def is_pathname_valid(pathname):
+    '''
+    `True` if the passed pathname is a valid pathname for the current OS;
+    `False` otherwise.
+    '''
+    # If this pathname is either not a string or is but is empty, this pathname
+    # is invalid.
+
+    # Sadly, Python fails to provide the following magic number for us.
+    ERROR_INVALID_NAME = 123
+    '''
+    Windows-specific error code indicating an invalid pathname.
+    
+    See Also
+    ----------
+    https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382%28v=vs.85%29.aspx
+        Official listing of all such codes.
+    '''
+
+    try:
+        if not is_string(pathname) or not pathname:
+            return False
+
+        # Strip this pathname's Windows-specific drive specifier (e.g., `C:\`)
+        # if any. Since Windows prohibits path components from containing `:`
+        # characters, failing to strip this `:`-suffixed prefix would
+        # erroneously invalidate all valid absolute Windows pathnames.
+        _, pathname = os.path.splitdrive(pathname)
+
+        # Directory guaranteed to exist. If the current OS is Windows, this is
+        # the drive to which Windows was installed (e.g., the "%HOMEDRIVE%"
+        # environment variable); else, the typical root directory.
+        root_dirname = os.environ.get('HOMEDRIVE', 'C:') \
+            if sys.platform == 'win32' else os.path.sep
+        assert os.path.isdir(root_dirname)   # ...Murphy and her ironclad Law
+
+        # Append a path separator to this directory if needed.
+        root_dirname = root_dirname.rstrip(os.path.sep) + os.path.sep
+
+        # Test whether each path component split from this pathname is valid or
+        # not, ignoring non-existent and non-readable path components.
+        for pathname_part in pathname.split(os.path.sep):
+            try:
+                os.lstat(root_dirname + pathname_part)
+            # If an OS-specific exception is raised, its error code
+            # indicates whether this pathname is valid or not. Unless this
+            # is the case, this exception implies an ignorable kernel or
+            # filesystem complaint (e.g., path not found or inaccessible).
+            #
+            # Only the following exceptions indicate invalid pathnames:
+            #
+            # * Instances of the Windows-specific "WindowsError" class
+            #   defining the "winerror" attribute whose value is
+            #   "ERROR_INVALID_NAME". Under Windows, "winerror" is more
+            #   fine-grained and hence useful than the generic "errno"
+            #   attribute. When a too-long pathname is passed, for example,
+            #   "errno" is "ENOENT" (i.e., no such file or directory) rather
+            #   than "ENAMETOOLONG" (i.e., file name too long).
+            # * Instances of the cross-platform "OSError" class defining the
+            #   generic "errno" attribute whose value is either:
+            #   * Under most POSIX-compatible OSes, "ENAMETOOLONG".
+            #   * Under some edge-case OSes (e.g., SunOS, *BSD), "ERANGE".
+            except OSError as exc:
+                if hasattr(exc, 'winerror'):
+                    if exc.winerror == ERROR_INVALID_NAME:
+                        return False
+                elif exc.errno in {errno.ENAMETOOLONG, errno.ERANGE}:
+                    return False
+            except ValueError:
+                # Python throws its own exceptions if a path isn't valid in some cases, e.g. e.g. 'path too long for Windows':
+                # https://github.com/python/cpython/blob/3.6/Modules/posixmodule.c#L929
+                return False
+    # If a "TypeError" exception was raised, it almost certainly has the
+    # error message "embedded NUL character" indicating an invalid pathname.
+    except TypeError as exc:
+        return False
+    # If no exception was raised, all path components and hence this
+    # pathname itself are valid. (Praise be to the curmudgeonly python.)
+    else:
+        return True
+        # If any other exception was raised, this is an unrelated fatal issue
+        # (e.g., a bug). Permit this exception to unwind the call stack.
+        #
+        # Did we mention this should be shipped with Python already?
 
 
 def is_url(string):


### PR DESCRIPTION
The easiest fix for #45 is just to catch the ValueError, but this is a more comprehensive solution that should handle the general case where a string is supplied that is not also a valid path name.