### PR TITLE
Workaround Path/XML string too long on Windows OS

### DIFF
--- a/untangle.py
+++ b/untangle.py
@@ -197,7 +197,7 @@ def parse(filename, **parser_features):
         parse_directly = is_string(filename) and (os.path.exists(filename) or
                                                   is_url(filename))
     except ValueError:  # Can only occur when is_string(filename) == True
-        parse_directly = is_url(filename)
+        parse_directly = is_string(filename) and is_url(filename)
     finally:
         parse_directly = parse_directly or hasattr(filename, "read")
         parser.parse(filename if parse_directly else StringIO(filename))


### PR DESCRIPTION
Provides a workaround for #45 (and #52?) when attempting to input a long XML string into `os.path.exists()` function when on Windows OS. 

For reference, the size of string must be ≥ 2^15 (or 32768) characters - at least on Windows 10 - to trigger the issue!