### PR TITLE
Make untangle available from conda-forge

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Christian Stefanescu <chris@0chris.com>
 Florian Idelberger <flo@terrorpop.de>
 Apalala <apalala@gmail.com>
 Reverb Chu <reverbc@me.com>
+Henrikki Tenkanen <henrikki.tenkanen@gmail.com>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ With conda:
 conda install -c conda-forge untangle
 ```
 
+Conda feedstock maintained by @htenkanen. Issues and questions about conda-forge packaging / installation can be done [here](https://github.com/conda-forge/untangle-feedstock/issues).
+
 Usage
 -----
 (See and run <a href="https://github.com/stchris/untangle/blob/master/examples.py">examples.py</a> or this blog post: [Read XML painlessly](http://pythonadventures.wordpress.com/2011/10/30/read-xml-painlessly/) for more info)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ With pip:
 pip install untangle
 ```
 
-Installation with conda:
+With conda:
 ```
 conda install -c conda-forge untangle
 ```

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ untangle
 Installation
 ------------
 
-Untangle can be easily installed with pip and conda package managers. 
-
-Installation with pip:
+With pip:
 ```
 pip install untangle
 ```

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ With conda:
 conda install -c conda-forge untangle
 ```
 
-
-
 Usage
 -----
 (See and run <a href="https://github.com/stchris/untangle/blob/master/examples.py">examples.py</a> or this blog post: [Read XML painlessly](http://pythonadventures.wordpress.com/2011/10/30/read-xml-painlessly/) for more info)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,19 @@ untangle
 Installation
 ------------
 
+Untangle can be easily installed with pip and conda package managers. 
+
+Installation with pip:
 ```
 pip install untangle
 ```
+
+Installation with conda:
+```
+conda install -c conda-forge untangle
+```
+
+
 
 Usage
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ It is recommended to use pip, which will always download the latest stable relea
 
     pip install untangle
 
-untangle works with Python versions 2.6, 2.7, 3.3, 3.4, 3.5, 3.6 and pypy
+untangle works with Python versions 2.6, 2.7, 3.3, 3.4, 3.5, 3.6 and pypy.
 
 Alternatively, you can install untangle with conda-forge: ::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,7 +56,7 @@ It is recommended to use pip, which will always download the latest stable relea
 
 untangle works with Python versions 2.6, 2.7, 3.3, 3.4, 3.5, 3.6 and pypy.
 
-Alternatively, you can install untangle with conda-forge: ::
+Alternatively, you can install untangle with conda from conda-forge: ::
 
     conda install -c conda-forge untangle
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,10 @@ It is recommended to use pip, which will always download the latest stable relea
 
 untangle works with Python versions 2.6, 2.7, 3.3, 3.4, 3.5, 3.6 and pypy
 
+Alternatively, you can install untangle with conda-forge: ::
+
+    conda install -c conda-forge untangle
+
 Motivation
 ----------
 


### PR DESCRIPTION
Closes #72 

Untangle has been added to conda-forge feedstock. Adds documentation about how to install with conda.