### PR TITLE
remove unnecessary shebang

### DIFF
--- a/untangle.py
+++ b/untangle.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """
  untangle
 


### PR DESCRIPTION
As file untangle.py is meant to be used only via import and not as directly executed commandline tool the shebang on the beginning is not needed.

The usage of the env python can also have its security implications. 

Having shebang on non-executable file is even being reported as error by some tools - for example Fedora/Red Hat's rpmlint: https://bugzilla.redhat.com/show_bug.cgi?id=2250689#c4

Best regards
Michal Ambroz